### PR TITLE
Monitor bug

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
       - name: install / build
         shell: pwsh
         run: |
-          conda install pytest pytest-cov coveralls mpich mcvine-core mantid-framework=4
+          conda install pytest pytest-cov coveralls openmpi mcvine-core mantid-framework=4
           python -c "import matplotlib; import mantid"
           mcvine
           python setup.py install

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,6 +58,7 @@ jobs:
         run: coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
       - name: conda build and upload
         shell: pwsh

--- a/mantid2mcvine/__init__.py
+++ b/mantid2mcvine/__init__.py
@@ -107,7 +107,11 @@ class InstrumentModel:
             self.nmonitors = nmonitors
         # create template nxs file
         from .nxs import template
-        template.create(self.mantid_idf, ntotpixels, self.template_nxs, workdir='template_nxs_work')
+        template.create(
+            self.mantid_idf, ntotpixels, self.template_nxs,
+            workdir='template_nxs_work',
+            nmonitors = self.nmonitors
+        )
         return
 
     def mantid_install(self, target=None):

--- a/mantid2mcvine/nxs/Events2Nxs.py
+++ b/mantid2mcvine/nxs/Events2Nxs.py
@@ -53,7 +53,7 @@ class Event2Nxs:
         pixelids = events['pixelID'] + self.nmonitors + 1
         hist, bin_edges = np.histogram(
             pixelids,
-            bins=np.arange(-0.5, self.monitors+self.npixels+1.5),
+            bins=np.arange(-0.5, self.nmonitors+self.npixels+1.5),
             )
         indices = np.cumsum(hist)
         nevents = len(events)

--- a/mantid2mcvine/nxs/Events2Nxs.py
+++ b/mantid2mcvine/nxs/Events2Nxs.py
@@ -53,7 +53,7 @@ class Event2Nxs:
         pixelids = events['pixelID'] + self.nmonitors + 1
         hist, bin_edges = np.histogram(
             pixelids,
-            bins=np.arange(self.nmonitors-0.5, self.nmonitors+self.npixels+1.5),
+            bins=np.arange(-0.5, self.monitors+self.npixels+1.5),
             )
         indices = np.cumsum(hist)
         nevents = len(events)


### PR DESCRIPTION
There were still some problems with preprocessed nexus file generated

* The indices in the template nxs only covered the detector pixels, not the monitors: https://github.com/mcvine/mantid2mcvine/blob/e868ed94b023721b691667704cb84a3a5a22b84e/mantid2mcvine/nxs/template.py#L31
* When mantid PreprocessDetectorsToMD is called (template.py), both monitors and detectors are included in the template nexus file: https://github.com/mcvine/mantid2mcvine/blob/e868ed94b023721b691667704cb84a3a5a22b84e/mantid2mcvine/nxs/template.py#L45
* In Event2Nexus.py, the implemented was wrong: https://github.com/mcvine/mantid2mcvine/blob/e868ed94b023721b691667704cb84a3a5a22b84e/mantid2mcvine/nxs/Events2Nxs.py#L56

They need to be fixed